### PR TITLE
refactor/atoms-from-js-to-ts

### DIFF
--- a/app/BoredAPI/page.tsx
+++ b/app/BoredAPI/page.tsx
@@ -7,7 +7,7 @@ import BoredAPIResult from "@/components/Molecules/BoredAPIResult";
 
 export default function BoredAPIPage() {
     const [localData, setLocalData] = useState({});
-    const [fetchData, setFetchData] = useState(null);
+    const [fetchData, setFetchData] = useState({});
     
     useEffect(() => {
         localStorage.hasOwnProperty('i-am-bored') && setLocalData(JSON.parse(localStorage.getItem('i-am-bored') || ""))

--- a/app/BoredAPI/page.tsx
+++ b/app/BoredAPI/page.tsx
@@ -7,16 +7,16 @@ import BoredAPIResult from "@/components/Molecules/BoredAPIResult";
 
 export default function BoredAPIPage() {
     const [localData, setLocalData] = useState({});
-    const [data, setData] = useState(null);
+    const [fetchData, setFetchData] = useState(null);
     
     useEffect(() => {
         localStorage.hasOwnProperty('i-am-bored') && setLocalData(JSON.parse(localStorage.getItem('i-am-bored') || ""))
     }, []);
 
     return (
-        <boredAPIContext.Provider value={{data, setData, localData, setLocalData}}>
+        <boredAPIContext.Provider value={{fetchData, setFetchData, localData, setLocalData}}>
             <BoredAPIForm />
-            {data && <BoredAPIResult />}
+            {fetchData && <BoredAPIResult />}
         </boredAPIContext.Provider>
     );
 }

--- a/components/Atoms/Button.js
+++ b/components/Atoms/Button.js
@@ -1,7 +1,0 @@
-import React from "react";
-
-export default function Button({type, text}) {
-    return (
-        <button className="border-2 border-slate-500 rounded-md px-2 hover:bg-sky-100" type={type}>{text}</button>
-    );
-}

--- a/components/Atoms/Button.tsx
+++ b/components/Atoms/Button.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+interface ButtonInterface {
+    text: string,
+    type: "submit" | "reset" | "button" | undefined,
+}
+
+const Button: React.FC<ButtonInterface> = ({type, text}) => {
+    return (
+        <button className="border-2 border-slate-500 rounded-md px-2 hover:bg-sky-100" type={type}>{text}</button>
+    );
+}
+
+export default Button;

--- a/components/Atoms/LabelledDropdown.tsx
+++ b/components/Atoms/LabelledDropdown.tsx
@@ -1,6 +1,13 @@
 import React from "react";
 
-export default function LabelledDropdown({id, text, list=[], update}) {
+interface LabelledDropdownInterface {
+    id: string,
+    text: string,
+    list: Array<string>,
+    update: (value:string) => {}
+}
+
+const LabelledDropdown: React.FC<LabelledDropdownInterface> = ({id, text, list=[], update}) => {
     return (
         <div>
             <label htmlFor={id} className="pr-2">{text}</label>
@@ -10,3 +17,5 @@ export default function LabelledDropdown({id, text, list=[], update}) {
         </div>
     );
 }
+
+export default LabelledDropdown;

--- a/components/Atoms/LabelledInput.tsx
+++ b/components/Atoms/LabelledInput.tsx
@@ -13,10 +13,10 @@ const LabelledInput:React.FC<LabelledInputInterface> = ({type, id, text, placeho
     const [input, setInput] = useState('');
     const { localData } = useContext(boredAPIContext);
 
-    console.log(localData);
-
-    const handleRecommendationClick = (e: React.ChangeEvent<HTMLInputElement>) => {
-        setInput(e.currentTarget.value);
+    const handleRecommendationClick = (event: React.MouseEvent) => {
+        const input = event.target as HTMLElement;
+        setInput(input.innerText);
+        event.preventDefault();
     }
 
     return (
@@ -33,7 +33,7 @@ const LabelledInput:React.FC<LabelledInputInterface> = ({type, id, text, placeho
                 4. user input not equal to the recommendation
                 */}
                 {recommendation && input && localData[id] &&
-                localData[id].map((data) => data.toLowerCase().includes(input.toLowerCase()) && input.toLowerCase() !== data.toLowerCase() &&
+                localData[id].map((data:string) => data.toLowerCase().includes(input.toLowerCase()) && input.toLowerCase() !== data.toLowerCase() &&
                     <button key={data} className="flex hover:invert" value={data} onClick={handleRecommendationClick}>
                         <div className={`text-sky-300`}>
                             &#9668;

--- a/components/Atoms/LabelledInput.tsx
+++ b/components/Atoms/LabelledInput.tsx
@@ -43,14 +43,14 @@ const LabelledInput:React.FC<LabelledInputInterface> = ({type, id, text, placeho
             <div className="inline-flex mt-1">
                 {hasRecommendationID() &&
                 localData[id].map((recommendationStr:string) => hasRecommendationString(recommendationStr) &&
-                    <button key={recommendationStr} className="flex hover:invert" value={recommendationStr} onClick={handleRecommendationClick}>
+                    <>  
                         <div className={`text-sky-300`}>
                             &#9668;
                         </div>
-                        <div className={`px-1 bg-sky-300 rounded-md`}>
-                            <div>{recommendationStr}</div>
-                        </div>
-                    </button>
+                        <button key={recommendationStr} className="flex hover:invert px-1 bg-sky-300 rounded-md" value={recommendationStr} onClick={handleRecommendationClick}>
+                            {recommendationStr}
+                        </button>
+                    </>
                 )}
             </div>
         </div>

--- a/components/Atoms/LabelledInput.tsx
+++ b/components/Atoms/LabelledInput.tsx
@@ -13,17 +13,31 @@ const LabelledInput:React.FC<LabelledInputInterface> = ({type, id, text, placeho
     const [input, setInput] = useState('');
     const { localData } = useContext(boredAPIContext);
 
+    const handleInputUpdate = (e: React.FormEvent<HTMLInputElement>) => {
+        setInput(e.currentTarget.value);
+        e.preventDefault();
+    }
+
     const handleRecommendationClick = (event: React.MouseEvent) => {
         const input = event.target as HTMLElement;
         setInput(input.innerText);
         event.preventDefault();
     }
 
+    const hasRecommendationID = () => {
+        const localData = {};
+        return (
+            recommendation &&
+            input &&
+            localData[id] &&
+            localData[id].map((data:string) => data.toLowerCase().includes(input.toLowerCase()) && input.toLowerCase() !== data.toLowerCase()))
+    }
+
     return (
         <div>
             <label htmlFor={id} className="pr-2">{text}</label>
             <input type={type} id={`${recommendation ? "recommendation-" : ""}${id}`} name={text} value={input} autoComplete="off" required
-            placeholder={placeholder} onChange={(e) => setInput(e.currentTarget.value)}
+            placeholder={placeholder} onChange={handleInputUpdate}
             className="border-2 border-slate-300 rounded-md px-2 py-1"/>
             <div className="inline-flex mt-1">
                 {/* show recommendations when:

--- a/components/Atoms/LabelledInput.tsx
+++ b/components/Atoms/LabelledInput.tsx
@@ -6,13 +6,12 @@ interface LabelledInputInterface {
     id: string,
     text: string,
     placeholder: string,
-    recommendation: boolean
+    recommend: boolean
 }
 
-const LabelledInput:React.FC<LabelledInputInterface> = ({type, id, text, placeholder, recommendation=false}) => {
+const LabelledInput:React.FC<LabelledInputInterface> = ({type, id, text, placeholder, recommend=false}) => {
     const [input, setInput] = useState('');
     const { localData } = useContext(boredAPIContext);
-    let recommendationList = localData[id];
 
     function handleInputUpdate (e: React.FormEvent<HTMLInputElement>) {
         setInput(e.currentTarget.value);
@@ -27,7 +26,7 @@ const LabelledInput:React.FC<LabelledInputInterface> = ({type, id, text, placeho
 
     // check if recommendation is on, user typed, and id existed in localData
     function hasRecommendationID () {
-        return recommendation && input && recommendationList;
+        return recommend && input && localData[id];
     }
 
     // check if input existed in recommendation list, and input does not equal to the recommendation
@@ -38,12 +37,12 @@ const LabelledInput:React.FC<LabelledInputInterface> = ({type, id, text, placeho
     return (
         <div>
             <label htmlFor={id} className="pr-2">{text}</label>
-            <input type={type} id={`${recommendation ? "recommendation-" : ""}${id}`} name={text} value={input} autoComplete="off" required
+            <input type={type} id={`${recommend ? "recommendation-" : ""}${id}`} name={text} value={input} autoComplete="off" required
             placeholder={placeholder} onChange={handleInputUpdate}
             className="border-2 border-slate-300 rounded-md px-2 py-1"/>
             <div className="inline-flex mt-1">
                 {hasRecommendationID() &&
-                recommendationList.map((recommendationStr:string) => hasRecommendationString(recommendationStr) &&
+                localData[id].map((recommendationStr:string) => hasRecommendationString(recommendationStr) &&
                     <button key={recommendationStr} className="flex hover:invert" value={recommendationStr} onClick={handleRecommendationClick}>
                         <div className={`text-sky-300`}>
                             &#9668;

--- a/components/Atoms/LabelledInput.tsx
+++ b/components/Atoms/LabelledInput.tsx
@@ -1,11 +1,21 @@
 import React, { useState, useContext } from "react";
 import { boredAPIContext } from "../Context";
 
-export default function LabelledInput({type, id, text, placeholder, recommendation=false}) {
-    const [input, setInput] = useState('');
-    const {localData} = useContext(boredAPIContext);
+interface LabelledInputInterface {
+    type: string,
+    id: string,
+    text: string,
+    placeholder: string,
+    recommendation: boolean
+}
 
-    const handleRecommendationClick = (e) => {
+const LabelledInput:React.FC<LabelledInputInterface> = ({type, id, text, placeholder, recommendation=false}) => {
+    const [input, setInput] = useState('');
+    const { localData } = useContext(boredAPIContext);
+
+    console.log(localData);
+
+    const handleRecommendationClick = (e: React.ChangeEvent<HTMLInputElement>) => {
         setInput(e.currentTarget.value);
     }
 
@@ -37,3 +47,5 @@ export default function LabelledInput({type, id, text, placeholder, recommendati
         </div>
     );
 }
+
+export default LabelledInput;

--- a/components/Atoms/LabelledInput.tsx
+++ b/components/Atoms/LabelledInput.tsx
@@ -12,6 +12,7 @@ interface LabelledInputInterface {
 const LabelledInput:React.FC<LabelledInputInterface> = ({type, id, text, placeholder, recommendation=false}) => {
     const [input, setInput] = useState('');
     const { localData } = useContext(boredAPIContext);
+    let recommendationList = localData[id];
 
     function handleInputUpdate (e: React.FormEvent<HTMLInputElement>) {
         setInput(e.currentTarget.value);
@@ -26,7 +27,7 @@ const LabelledInput:React.FC<LabelledInputInterface> = ({type, id, text, placeho
 
     // check if recommendation is on, user typed, and id existed in localData
     function hasRecommendationID () {
-        return recommendation && input && localData[id];
+        return recommendation && input && recommendationList;
     }
 
     // check if input existed in recommendation list, and input does not equal to the recommendation
@@ -42,7 +43,7 @@ const LabelledInput:React.FC<LabelledInputInterface> = ({type, id, text, placeho
             className="border-2 border-slate-300 rounded-md px-2 py-1"/>
             <div className="inline-flex mt-1">
                 {hasRecommendationID() &&
-                localData[id].map((recommendationStr:string) => hasRecommendationString(recommendationStr) &&
+                recommendationList.map((recommendationStr:string) => hasRecommendationString(recommendationStr) &&
                     <button key={recommendationStr} className="flex hover:invert" value={recommendationStr} onClick={handleRecommendationClick}>
                         <div className={`text-sky-300`}>
                             &#9668;

--- a/components/Atoms/LabelledInput.tsx
+++ b/components/Atoms/LabelledInput.tsx
@@ -13,24 +13,25 @@ const LabelledInput:React.FC<LabelledInputInterface> = ({type, id, text, placeho
     const [input, setInput] = useState('');
     const { localData } = useContext(boredAPIContext);
 
-    const handleInputUpdate = (e: React.FormEvent<HTMLInputElement>) => {
+    function handleInputUpdate (e: React.FormEvent<HTMLInputElement>) {
         setInput(e.currentTarget.value);
         e.preventDefault();
     }
 
-    const handleRecommendationClick = (event: React.MouseEvent) => {
+    function handleRecommendationClick (event: React.MouseEvent) {
         const input = event.target as HTMLElement;
         setInput(input.innerText);
         event.preventDefault();
     }
 
-    const hasRecommendationID = () => {
-        const localData = {};
-        return (
-            recommendation &&
-            input &&
-            localData[id] &&
-            localData[id].map((data:string) => data.toLowerCase().includes(input.toLowerCase()) && input.toLowerCase() !== data.toLowerCase()))
+    // check if recommendation is on, user typed, and id existed in localData
+    function hasRecommendationID () {
+        return recommendation && input && localData[id];
+    }
+
+    // check if input existed in recommendation list, and input does not equal to the recommendation
+    function hasRecommendationString (recommendationStr:string) {
+        return recommendationStr.toLowerCase().includes(input.toLowerCase()) && input.toLowerCase() !== recommendationStr.toLowerCase();
     }
 
     return (
@@ -40,20 +41,14 @@ const LabelledInput:React.FC<LabelledInputInterface> = ({type, id, text, placeho
             placeholder={placeholder} onChange={handleInputUpdate}
             className="border-2 border-slate-300 rounded-md px-2 py-1"/>
             <div className="inline-flex mt-1">
-                {/* show recommendations when:
-                1. recommendation is on (default is off)
-                2. user typed
-                3. JSON list includes input string (not case sensitive)
-                4. user input not equal to the recommendation
-                */}
-                {recommendation && input && localData[id] &&
-                localData[id].map((data:string) => data.toLowerCase().includes(input.toLowerCase()) && input.toLowerCase() !== data.toLowerCase() &&
-                    <button key={data} className="flex hover:invert" value={data} onClick={handleRecommendationClick}>
+                {hasRecommendationID() &&
+                localData[id].map((recommendationStr:string) => hasRecommendationString(recommendationStr) &&
+                    <button key={recommendationStr} className="flex hover:invert" value={recommendationStr} onClick={handleRecommendationClick}>
                         <div className={`text-sky-300`}>
                             &#9668;
                         </div>
                         <div className={`px-1 bg-sky-300 rounded-md`}>
-                            <div>{data}</div>
+                            <div>{recommendationStr}</div>
                         </div>
                     </button>
                 )}

--- a/components/Atoms/LabelledSlider.tsx
+++ b/components/Atoms/LabelledSlider.tsx
@@ -1,6 +1,16 @@
 import React from "react";
 
-export default function LabelledSlider({id, text, min, max, minText, maxText, step}) {
+interface LabelledSliderInterface {
+    id: string,
+    text: string,
+    min: number,
+    max: number,
+    minText: string,
+    maxText: string,
+    step: number
+}
+
+const LabelledSlider:React.FC<LabelledSliderInterface> = ({id, text, min, max, minText, maxText, step}) => {
 
     return (
         <div className="py-1">
@@ -11,3 +21,5 @@ export default function LabelledSlider({id, text, min, max, minText, maxText, st
         </div>
     );
 }
+
+export default LabelledSlider;

--- a/components/Atoms/Nav.tsx
+++ b/components/Atoms/Nav.tsx
@@ -2,10 +2,17 @@ import Link from "next/link";
 import { navBarContext } from "../Context";
 import { useContext } from "react";
 
-export default function Nav({path="/", name=""}) {
+interface NavInterface {
+    path: string,
+    name: string
+}
+
+const Nav:React.FC<NavInterface> = ({path="/", name=""}) => {
     const {curNav, setCurNav} = useContext(navBarContext);
 
     return(
         <Link className={`nav ${curNav===path && "nav-selected"}`} href={path} onClick={() => setCurNav(path)}>{name}</Link>
     );
 }
+
+export default Nav;

--- a/components/Context.js
+++ b/components/Context.js
@@ -1,4 +1,0 @@
-import { createContext } from "react";
-
-export const boredAPIContext = createContext({});
-export const navBarContext = createContext({});

--- a/components/Context.ts
+++ b/components/Context.ts
@@ -13,4 +13,10 @@ interface boredAPIContextLocalDataInterface {
 interface boredAPIContextInterface extends boredAPIContextFetchDataInterface, boredAPIContextLocalDataInterface {}
 
 export const boredAPIContext = createContext({} as boredAPIContextInterface);
-export const navBarContext = createContext({});
+
+interface navBarContextInterface {
+    curNav: string,
+    setCurNav: Dispatch<SetStateAction<{}>>;
+}
+
+export const navBarContext = createContext({} as navBarContextInterface);

--- a/components/Context.ts
+++ b/components/Context.ts
@@ -1,11 +1,14 @@
 import { createContext } from "react";
 
-interface borderAPIContextInterface {
-    data: {},
-    setData: () => {},
+interface boredAPIContextFetchDataInterface {
+    fetchData: null,
+    setFetchData: () => {}
+}
+
+interface boredAPIContextLocalDataInterface {
     localData: {},
     setLocalData: () => {}
-};
+}
 
-export const boredAPIContext = createContext<borderAPIContextInterface | {}>({});
+export const boredAPIContext = createContext<boredAPIContextFetchDataInterface | boredAPIContextLocalDataInterface | {}>({});
 export const navBarContext = createContext({});

--- a/components/Context.ts
+++ b/components/Context.ts
@@ -1,14 +1,16 @@
-import { createContext } from "react";
+import { createContext, Dispatch, SetStateAction } from "react";
 
 interface boredAPIContextFetchDataInterface {
-    fetchData: null,
-    setFetchData: () => {}
+    fetchData: {},
+    setFetchData: Dispatch<SetStateAction<{}>>;
 }
 
 interface boredAPIContextLocalDataInterface {
     localData: {},
-    setLocalData: () => {}
+    setLocalData: Dispatch<SetStateAction<{}>>;
 }
 
-export const boredAPIContext = createContext<boredAPIContextFetchDataInterface | boredAPIContextLocalDataInterface | {}>({});
+interface boredAPIContextInterface extends boredAPIContextFetchDataInterface, boredAPIContextLocalDataInterface {}
+
+export const boredAPIContext = createContext({} as boredAPIContextInterface);
 export const navBarContext = createContext({});

--- a/components/Context.ts
+++ b/components/Context.ts
@@ -6,7 +6,7 @@ interface boredAPIContextFetchDataInterface {
 }
 
 interface boredAPIContextLocalDataInterface {
-    localData: {},
+    localData: { [key: string]: string[] },
     setLocalData: Dispatch<SetStateAction<{}>>;
 }
 

--- a/components/Context.ts
+++ b/components/Context.ts
@@ -1,0 +1,11 @@
+import { createContext } from "react";
+
+interface borderAPIContextInterface {
+    data: {},
+    setData: () => {},
+    localData: {},
+    setLocalData: () => {}
+};
+
+export const boredAPIContext = createContext<borderAPIContextInterface | {}>({});
+export const navBarContext = createContext({});

--- a/components/Molecules/BoredAPIForm.js
+++ b/components/Molecules/BoredAPIForm.js
@@ -6,7 +6,7 @@ import LabelledDropDown from "../Atoms/LabelledDropdown";
 import Button from "../Atoms/Button";
 
 export default function BoredAPIForm() {
-    const {setData, setLocalData} = useContext(boredAPIContext);
+    const {setFetchData, setLocalData} = useContext(boredAPIContext);
     const [activity, setActivity] = useState("random");
     const RECOMMENDATION_NUM = 5;
 
@@ -81,11 +81,11 @@ export default function BoredAPIForm() {
             const res = await fetch(`${basedUrl}${additionalURL}`);
             if(res.ok){
                 const data = await res.json();
-                setData(data);
+                setFetchData(data);
             }
         }catch(err){
             console.error('Error: ', err);
-            setData(err);
+            setFetchData(err);
         }
     }
 

--- a/components/Molecules/BoredAPIForm.js
+++ b/components/Molecules/BoredAPIForm.js
@@ -91,7 +91,7 @@ export default function BoredAPIForm() {
 
     return (
         <form onSubmit={handleOnSubmit}>
-            <LabelledInput type='text' id='name' text='Your name:' placeholder='Enter your name' recommendation={true}/>
+            <LabelledInput type='text' id='name' text='Your name:' placeholder='Enter your name' recommend={true}/>
             <LabelledDropDown id='activity' text='What is the metric you want the activity based on?' list={["random", "participants", "accessibility", "price", "type"]} update={setActivity}/>
             <div className="py-3">{component[activity]}</div>
             <Button type='submit' text='Submit'/>

--- a/components/Molecules/BoredAPIResult.js
+++ b/components/Molecules/BoredAPIResult.js
@@ -3,13 +3,13 @@ import { boredAPIContext } from "../Context";
 import Link from "next/link";
 
 export default function BoredAPIResult (){
-    const {data} = useContext(boredAPIContext);
+    const {fetchData} = useContext(boredAPIContext);
 
     return (
         <div className="grid">
-            {data.error && <>{`Error: ${data.error}`}</>}
-            {data.activity}
-            {data.link && <Link href={data.link} target="_blank">{data.link}</Link>}
+            {fetchData.error && <>{`Error: ${fetchData.error}`}</>}
+            {fetchData.activity}
+            {fetchData.link && <Link href={fetchData.link} target="_blank">{fetchData.link}</Link>}
         </div>
     );
 }


### PR DESCRIPTION
### Button
- convert `Button.js` into `Button.tsx`
- add interface for Button component

### LabelledDropdown
- convert `LabelledDropdown.js` into `LabelledDropdown.tsx`
- add interface for LabelledDropdown component

### LabelledInput
- convert `LabelledInput.js` into `LabelledInput.tsx`
- convert `Context.js` into `Context.ts`
- add interface for LabelledInput component
- add type for event handler
- rename variable on `page.tsx` useState for clarity. From `[data, setData]` to `[fetchData, setFetchData]`
- split interface for clarity and management on `Context.ts`
- create event handler for input update. Standardize event handler using standalone function 
- create functions for checking recommendations, then display accordingly
- update interface for `localData` and `fetchData` on useState
- fix type error for accessing `localData`
- rename variable on `LabelledInput` for better clarity. From `recommendation` to `recommend`
- fix a bug where clicking on the arrow next to the recommendation string would result in updating the input field into arrow instead of recommendation string
- rearrange how the recommendation code are structure to follow button best practice - no more nested div blocks inside the button block

### LabelledSlider
- convert `LabelledSlider.js` into `LabelledSlider.tsx`
- add interface for LabelledSlider component

### Nav
- convert `Nav.js` into `Nav.tsx`
- add interface for Nav component
- update navBarContext with a interface